### PR TITLE
try-pg-except-sqlite

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,4 +1,4 @@
-"""Application configuration classes."""
+"""Application configuration."""
 import os
 basedir = os.path.abspath(os.path.dirname(__file__))
 
@@ -9,29 +9,32 @@ class Config:
     CSRF_ENABLED = True
     WTF_CSRF_ENABLED = True
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+    try:
+        SQLALCHEMY_DATABASE_URI = os.environ['DATABASE_URL']
+    except KeyError:
+        SQLALCHEMY_DATABASE_URI = \
+            'sqlite:///'+os.path.join(basedir, 'data/dev.db')
 
 
 class StagingConfig(Config):
     """Production configuration."""
-    SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL')
+    pass
 
 
 class ProductionConfig(Config):
     """Production configuration."""
-    SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL')
+    pass
 
 
 class DevelopmentConfig(Config):
     """Development configuration."""
     DEBUG = True
     SQLALCHEMY_ECHO = True
-    SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(basedir, 'dev.db')
 
 
 config = {
+    'default': DevelopmentConfig,
     'development': DevelopmentConfig,
     'production': ProductionConfig,
-    'staging': StagingConfig,
-    # And the default is...
-    'default': DevelopmentConfig
+    'staging': StagingConfig
 }


### PR DESCRIPTION
We should be using our production RDBMS in development as well. That is postgres. I added a try/except if you want to use sqlite for now, but I moved the sqlite db to /data.