### PR TITLE
sqlalchemy-deprecation-fix

### DIFF
--- a/pma_api/models.py
+++ b/pma_api/models.py
@@ -147,7 +147,7 @@ class WbMetadata(db.Model):
     name = db.Column(db.String, unique=True)
     type = db.Column(db.String, index=True)
     md5_checksum = db.Column(db.String)
-    blob = db.Column(db.Binary)
+    blob = db.Column(db.LargeBinary)
     created_on = db.Column(db.DateTime, default=db.func.now(),
                            onupdate=db.func.now(), index=True)
 


### PR DESCRIPTION
Fixed deprecation issue.
```/Users/joeflack4/virtualenvs/pma-api/lib/python3.6/site-packages/sqlalchemy/util/langhelpers.py:1042: SADeprecationWarning: The Binary type has been renamed to LargeBinary.```